### PR TITLE
StoreFiles 更新下载链接

### DIFF
--- a/etc/StoreFiles
+++ b/etc/StoreFiles
@@ -1,3 +1,3 @@
-https://github.com/XTLS/Xray-core/releases/latest/download/Xray-windows-64.zip
-https://github.com/p4gefau1t/trojan-go/releases/download/v0.8.2/trojan-go-windows-amd64.zip
+https://github.com/v2fly/v2ray-core/releases/download/v4.41.1/v2ray-linux-64.zip
+https://github.com/p4gefau1t/trojan-go/releases/download/v0.10.4/trojan-go-linux-amd64.zip
 https://github.com/shadowsocks/shadowsocks-windows/releases/download/4.4.0.0/Shadowsocks-4.4.0.185.zip


### PR DESCRIPTION
xray超过2月未更新，已替换到v2ray
trojan-go、ss已有新版本